### PR TITLE
Travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# .travis.yml
+sudo: false
+language: cpp
+os: linux
+compiler: gcc #TODO + clang
+addons:
+  apt:
+    sources: ['ubuntu-toolchain-r-test', 'kalakris-cmake'] #TODO + 'llvm-toolchain-precise-3.7'
+    packages: ['g++-4.8', 'cmake'] #TODO + 'clang-3.7'
+before_script:
+  - mkdir ../build
+  - cd ../build
+script:
+  - export CC=gcc-4.8
+  - export CXX=g++-4.8
+  - ldd --version
+  - cmake -DBUILD_TESTS=ON -DBUILD_SAMPLES=OFF ../vmf
+  - make
+  - cd ./bin/
+  - ./unit-tests
+  - ./unit-tests-ds
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/01org/vmf.svg?branch=master)](https://travis-ci.org/01org/vmf)
+
 Video Metadata Framework
 ------------------------
 

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -72,6 +72,10 @@ if(APPLE AND NOT IOS)
   target_link_libraries(${VMF_LIBRARY_NAME} "-framework CoreFoundation" "-framework CoreServices")
 endif()
 
+if(UNIX AND NOT APPLE)
+  # fix build with glibc < 2.17
+  target_link_libraries(${VMF_LIBRARY_NAME} rt)
+endif()
 
 if(BUILD_SHARED_LIBS AND WIN32)
     append_target_property(${VMF_LIBRARY_NAME} COMPILE_FLAGS "-DVMF_API_EXPORT")


### PR DESCRIPTION
Login to https://travis-ci.org with GitHub account that can manage the `01org/vmf` project and enable travis builds (see http://docs.travis-ci.com/user/for-beginners/ for details).

This isn't a replacement for full-featured local CI system, but is a good free complement for it.
