### PR TITLE
- add Matroska (MKV) format support

### DIFF
--- a/3rdparty/xmp/XMPFiles/source/FileHandlers/Matroska_Handler.cpp
+++ b/3rdparty/xmp/XMPFiles/source/FileHandlers/Matroska_Handler.cpp
@@ -1,0 +1,266 @@
+// =================================================================================================
+// ADOBE SYSTEMS INCORPORATED
+// Copyright 2016 Adobe Systems Incorporated
+// All Rights Reserved
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+// =================================================================================================
+
+#include "XMPFiles/source/FileHandlers/Matroska_Handler.hpp"
+#include "XMPFiles/source/FormatSupport/EBML_Support.hpp"
+#include "XMPFiles/source/FormatSupport/EBML/ids.h"
+#include "XMPFiles/source/FormatSupport/EBML/exceptions.h"
+#include "XMPFiles/source/FormatSupport/EBML/variant.h"
+#include "XMPFiles/source/FormatSupport/EBML/element.h"
+
+using namespace ebml;
+
+// =================================================================================================
+// Matroska_CheckFormat
+// ===============
+//
+// A Matroska file must begin with EBML [1A][45][DF][A3], a 4 byte length
+
+class MatroskaDOM
+{
+public:
+    MatroskaDOM(XMP_IO * fileRef)
+    {
+        assert(fileRef);
+        fileRef->Rewind();
+
+        _root = std::make_shared<ebml_element_t>(ebml_type_t::kEBMLTypeMaster, fileRef->Length());
+
+        ebml_restrictions restrictions;
+        restrictions.max_id_length = 4;
+        restrictions.max_size_length = 8;
+
+        ReadEBMLMaster(fileRef, _root, restrictions, 0, std::bind(&MatroskaDOM::OnElement, this, std::placeholders::_1));
+
+        auto segments = _root->getElementsById(kSegment);
+        if (segments.empty()) throw no_elements();
+    }
+    bool OnElement(ebml_element_t::ptr element)
+    {
+        return true;
+    }
+    ebml_element_t::ptr _root;
+};
+
+bool Matroska_CheckFormat(XMP_FileFormat  format,
+    XMP_StringPtr    filePath,
+    XMP_IO*      	file,
+    XMPFiles*        parent)
+{
+    IgnoreParam(format); IgnoreParam(parent);
+    XMP_Assert(format == kXMP_MatroskaFile);
+
+    try
+    {
+        MatroskaDOM DOM(file);
+
+        return true;
+    }
+    catch (std::logic_error &)
+    {
+        return false;
+    }
+}	// Matroska_CheckFormat
+
+extern XMPFileHandler * Matroska_MetaHandlerCTor(XMPFiles * parent)
+{
+    return new Matroska_MetaHandler(parent);
+}
+
+Matroska_MetaHandler::Matroska_MetaHandler(XMPFiles* parent)
+    : XMPFileHandler(parent)
+{
+    this->parent = parent;
+    this->handlerFlags = kMatroska_HandlerFlags;
+    this->stdCharForm = kXMP_Char8Bit;
+}
+
+void Matroska_MetaHandler::CacheFileData()
+{
+    XMP_Assert(parent && parent->ioRef);
+    try
+    {
+        containsXMP = false;
+        _dom = std::make_shared<MatroskaDOM>(parent->ioRef);
+
+        for (auto segment : _dom->_root->getElementsById(kSegment))
+        {
+            for (auto tags : segment->getElementsById(kTags))
+            {
+                for (auto tag : tags->getElementsById(kTag))
+                {
+                    for (auto simple_tag : tag->getElementsById(kSimpleTag))
+                    {
+                        auto tag_name = simple_tag->getElementById(kTagName);
+                        if (tag_name->_value.StringValue == "XMP")
+                        {
+                            auto tag_string = simple_tag->getElementById(kTagString);
+
+                            xmpPacket = tag_string->_value.StringValue;
+                            containsXMP = true;
+
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    catch (std::logic_error & e)
+    {
+        e.what();
+        XMP_Validate(false, e.what(), kXMPErr_BadFileFormat);
+    }
+}
+
+void Matroska_MetaHandler::UpdateFile(bool doSafeUpdate)
+{
+    if (!needsUpdate) return; // If needsUpdate is set then at least the XMP changed.
+
+    needsUpdate = false;	// Make sure only called once.
+    XMP_Assert(!doSafeUpdate);	// This should only be called for "unsafe" updates.
+    XMP_Assert(parent && parent->ioRef);
+
+    XMP_AbortProc abortProc = parent->abortProc;
+    void *        abortArg = parent->abortArg;
+    const bool    checkAbort = (abortProc != 0);
+
+    bool localProgressTracking(false);
+    XMP_ProgressTracker* progressTracker = parent->progressTracker;
+    if (progressTracker)
+    {
+        float xmpSize = static_cast<float>(xmpPacket.size());
+        if (progressTracker->WorkInProgress())
+        {
+            progressTracker->AddTotalWork(xmpSize);
+        }
+        else
+        {
+            localProgressTracking = true;
+            progressTracker->BeginWork(xmpSize);
+        }
+    }
+    UpdateXMP();
+
+    if (localProgressTracking) progressTracker->WorkComplete();
+}
+
+void Matroska_MetaHandler::UpdateXMP()
+{
+    XMP_IO* fileRef = parent->ioRef;
+
+    fileRef->Seek(fileRef->Length(), kXMP_SeekFromStart);
+
+    for (auto segment : _dom->_root->getElementsById(kSegment))
+    {
+        for (auto tags : segment->getElementsById(kTags))
+        {
+            for (auto tag : tags->getElementsById(kTag))
+            {
+                for (auto simple_tag : tag->getElementsById(kSimpleTag))
+                {
+                    auto tag_name = simple_tag->getElementById(kTagName);
+                    if (tag_name->_value.StringValue == "XMP")
+                    {
+                        auto tag_string = simple_tag->getElementById(kTagString);
+
+                        // we have found valid XMP, and if it's in the very end of file, we can truncate segment
+                        if (tag_string->_offset + tag_string->size() == fileRef->Length())
+                        {
+                            segment->_size._value -= tags->size();
+
+                            fileRef->Truncate(tags->_offset);
+                            fileRef->Seek(tags->_offset, kXMP_SeekFromStart);
+                        }
+                        // otherwise, make old XMP tag Void and create new one from the scratch
+                        else
+                        {
+                            tags->wipe(fileRef);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    auto segments = _dom->_root->getElementsById(kSegment);
+    auto segment = segments.back();
+
+    auto tag_name = std::make_shared<ebml_element_t>(kTagName, ebml_variant_t("XMP"));
+    auto tag_string = std::make_shared<ebml_element_t>(kTagString, ebml_variant_t(xmpPacket));
+    auto tag_language = std::make_shared<ebml_element_t>(kTagLanguage, ebml_variant_t("eng"));
+    auto tag_default = std::make_shared<ebml_element_t>(kTagDefault, ebml_variant_t(1ULL));
+    auto simple_tag = std::make_shared<ebml_element_t>(kSimpleTag, ebml_element_t::vec{ tag_language, tag_default, tag_name, tag_string });
+    auto tag = std::make_shared<ebml_element_t>(kTag, simple_tag);
+    auto tags = std::make_shared<ebml_element_t>(kTags, tag);
+
+    tags->write(fileRef);
+
+    segment->_size._value += tags->size();
+    segment->update_header(fileRef);
+}
+
+void Matroska_MetaHandler::WriteTempFile(XMP_IO* tempRef)
+{
+    XMP_Assert(needsUpdate);
+
+    XMP_IO* originalRef = parent->ioRef;
+    
+    bool localProgressTracking(false);
+    XMP_ProgressTracker* progressTracker = parent->progressTracker;
+    if (progressTracker)
+    {
+        float xmpSize = static_cast<float>(xmpPacket.size());
+        if (progressTracker->WorkInProgress())
+        {
+            progressTracker->AddTotalWork(xmpSize);
+        }
+        else
+        {
+            localProgressTracking = true;
+            progressTracker->BeginWork(xmpSize);
+        }
+    }
+
+    XMP_Assert(tempRef);
+    XMP_Assert(originalRef);
+
+    tempRef->Rewind();
+    originalRef->Rewind();
+    XIO::Copy(originalRef, tempRef, originalRef->Length(), parent->abortProc, parent->abortArg);
+
+    try
+    {
+        parent->ioRef = tempRef;	// ! Fool UpdateFile into using the temp file.
+        UpdateFile(false);
+        parent->ioRef = originalRef;
+    }
+    catch (...)
+    {
+        parent->ioRef = originalRef;
+        throw;
+    }
+    if (localProgressTracking) progressTracker->WorkComplete();
+}
+
+void Matroska_MetaHandler::ProcessXMP()
+{
+    if (processedXMP) return;
+    processedXMP = true;	// Make sure we only come through here once.
+
+    // Process the XMP packet.
+
+    if (!xmpPacket.empty())
+    {
+        XMP_Assert(containsXMP);
+
+        xmpObj.ParseFromBuffer(xmpPacket.c_str(), static_cast<XMP_StringLen>(xmpPacket.size()));
+
+        containsXMP = true;
+    }
+}

--- a/3rdparty/xmp/XMPFiles/source/FileHandlers/Matroska_Handler.hpp
+++ b/3rdparty/xmp/XMPFiles/source/FileHandlers/Matroska_Handler.hpp
@@ -1,0 +1,57 @@
+// =================================================================================================
+// ADOBE SYSTEMS INCORPORATED
+// Copyright 2016 Adobe Systems Incorporated
+// All Rights Reserved
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+// =================================================================================================
+
+#ifndef __Matroska_Handler_hpp__
+#define __Matroska_Handler_hpp__	1
+
+#include "public/include/XMP_Environment.h"	// ! XMP_Environment.h must be the first included header.
+#include "public/include/XMP_Const.h"
+
+#include "source/Endian.h"
+#include "source/XIO.hpp"
+
+#include "XMPFiles/source/XMPFiles_Impl.hpp"
+
+#include <memory>
+
+extern XMPFileHandler * Matroska_MetaHandlerCTor(XMPFiles * parent);
+
+extern bool Matroska_CheckFormat(XMP_FileFormat format,
+	XMP_StringPtr  filePath,
+	XMP_IO*	fileRef,
+	XMPFiles *	 parent);
+
+static constexpr XMP_OptionBits kMatroska_HandlerFlags = (kXMPFiles_CanInjectXMP |
+	kXMPFiles_CanExpand |
+	kXMPFiles_CanRewrite |
+	kXMPFiles_PrefersInPlace |
+	kXMPFiles_CanReconcile |
+	kXMPFiles_AllowsOnlyXMP |
+	kXMPFiles_ReturnsRawPacket |
+	kXMPFiles_AllowsSafeUpdate |
+	kXMPFiles_CanNotifyProgress
+	);
+
+class MatroskaDOM;
+
+class Matroska_MetaHandler : public XMPFileHandler
+{
+public:
+	explicit Matroska_MetaHandler(XMPFiles* parent);
+	~Matroska_MetaHandler() noexcept {}
+
+	void CacheFileData() override;
+	void UpdateFile(bool doSafeUpdate) override;
+	void WriteTempFile(XMP_IO* tempRef) override;
+	void ProcessXMP() override;
+	void UpdateXMP();
+	std::shared_ptr<MatroskaDOM> _dom;
+};
+
+#endif /* __Matroska_Handler_hpp__ */

--- a/3rdparty/xmp/XMPFiles/source/FileHandlers/Matroska_Handler.hpp
+++ b/3rdparty/xmp/XMPFiles/source/FileHandlers/Matroska_Handler.hpp
@@ -20,6 +20,12 @@
 
 #include <memory>
 
+#if !defined(_MSC_FULL_VER) || _MSC_FULL_VER < 190023026
+  // MSVC before 2015 doesn't support 'noexcept'
+  #define _ALLOW_KEYWORD_MACROS 1
+  #define noexcept throw()
+#endif
+
 extern XMPFileHandler * Matroska_MetaHandlerCTor(XMPFiles * parent);
 
 extern bool Matroska_CheckFormat(XMP_FileFormat format,
@@ -27,7 +33,7 @@ extern bool Matroska_CheckFormat(XMP_FileFormat format,
 	XMP_IO*	fileRef,
 	XMPFiles *	 parent);
 
-static constexpr XMP_OptionBits kMatroska_HandlerFlags = (kXMPFiles_CanInjectXMP |
+static const XMP_OptionBits kMatroska_HandlerFlags = (kXMPFiles_CanInjectXMP |
 	kXMPFiles_CanExpand |
 	kXMPFiles_CanRewrite |
 	kXMPFiles_PrefersInPlace |

--- a/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/element.cpp
+++ b/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/element.cpp
@@ -1,0 +1,115 @@
+// =================================================================================================
+// ADOBE SYSTEMS INCORPORATED
+// Copyright 2016 Adobe Systems Incorporated
+// All Rights Reserved
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+// =================================================================================================
+
+#include "XMPFiles/source/FormatSupport/EBML_Support.hpp"
+#include "XMPFiles/source/FormatSupport/EBML/ids.h"
+#include "XMPFiles/source/FormatSupport/EBML/exceptions.h"
+#include "XMPFiles/source/FormatSupport/EBML/variant.h"
+#include "XMPFiles/source/FormatSupport/EBML/element.h"
+
+namespace ebml
+{
+	ebml_size_t ebml_element_t::content_size() const
+	{
+		ebml_size_t result(0);
+
+		if (_value.type == ebml_type_t::kEBMLTypeMaster)
+		{
+			for (auto i : _children) result += i->size();
+		}
+		else result = _value.size();
+		return result;
+	}
+
+	ebml_size_t ebml_element_t::size() const
+	{
+		auto cs = content_size();
+		return cs + _id._length + size_for_int(cs);
+	}
+
+	void ebml_element_t::WriteVINT(XMP_IO * fileRef, const ebml_vint_t & value, bool adjust)
+	{
+		XMP_Assert(fileRef);
+
+		auto shift = value._length - 1;
+		ebml_size_t mask = (0x80 >> shift);
+		mask <<= shift * 8;
+		ebml_size_t v = adjust ? (value._value | mask) : value._value;
+
+		for (auto i = 0; i < value._length; ++i)
+		{
+			auto bits = value._length - i - 1;
+			auto shift = bits * 8;
+			XMP_Uns8 byte = (v >> shift) & 0xFF;
+			fileRef->Write(&byte, 1);
+		}
+	}
+
+	void ebml_element_t::write(XMP_IO* fileRef)
+	{
+		XMP_Assert(fileRef);
+
+		WriteVINT(fileRef, _id, false);
+		WriteVINT(fileRef, ebml_vint_t(content_size()), true);
+
+		if (_value.type == ebml_type_t::kEBMLTypeMaster) for (auto i : _children) i->write(fileRef);
+		else fileRef->Write(_value.data(), _value.size());
+	}
+
+	void ebml_element_t::update_header(XMP_IO* fileRef)
+	{
+		XMP_Assert(fileRef);
+
+		fileRef->Seek(_offset, kXMP_SeekFromStart);
+
+		WriteVINT(fileRef, _id, false);
+		WriteVINT(fileRef, _size, true);
+	}
+
+	void ebml_element_t::update_content(XMP_IO* fileRef)
+	{
+		XMP_Assert(fileRef);
+
+		fileRef->Seek(_offset, kXMP_SeekFromStart);
+
+		if (_value.type == ebml_type_t::kEBMLTypeMaster) throw invalid_type();
+		fileRef->Write(_value.data(), _value.size());
+	}
+
+	void ebml_element_t::wipe(XMP_IO * fileRef)
+	{
+		XMP_Assert(fileRef);
+
+		auto old_length = _id._length;
+
+		_id._value = kVoid;
+		_id._length = size_for_int(kVoid); // this is 1 byte
+
+		auto diff = old_length - _id._length;
+
+		_size._value += diff;
+
+		update_header(fileRef);
+	}
+
+	ebml::ebml_element_t::vec ebml_element_t::getElementsById(ebml_id_t id) const noexcept
+	{
+		vec result;
+		for (auto i : _children) if (id == i->_id._value) result.push_back(i);
+		return result;
+	}
+
+	ebml::ebml_element_t::ptr ebml_element_t::getElementById(ebml_id_t id) const
+	{
+		auto elements = getElementsById(id);
+		if (elements.empty()) throw no_elements();
+		return getElementsById(id).front();
+	}
+
+}

--- a/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/element.h
+++ b/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/element.h
@@ -1,0 +1,48 @@
+// =================================================================================================
+// ADOBE SYSTEMS INCORPORATED
+// Copyright 2016 Adobe Systems Incorporated
+// All Rights Reserved
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+// =================================================================================================
+
+#ifndef _EBML_element_h_
+#define _EBML_element_h_
+
+namespace ebml
+{
+	class ebml_element_t
+	{
+	public:
+		typedef std::shared_ptr<ebml_element_t> ptr;
+		typedef std::vector<ptr> vec;
+
+		explicit ebml_element_t() : _id(0), _size(0), _offset(0), _content(0), _level(0) {}
+		explicit ebml_element_t(ebml_type_t type, ebml_size_t size) : _id(0), _size(size), _offset(0), _content(0), _level(0) { _value.type = type; }
+		explicit ebml_element_t(ebml_id_t id) : _id(id), _size(0), _offset(0), _content(0), _level(0) {}
+		explicit ebml_element_t(ebml_id_t id, const ebml_variant_t & value) : _id(id), _size(0), _offset(0), _content(0), _level(0), _value(value) {}
+		explicit ebml_element_t(ebml_id_t id, ptr child) : _id(id), _size(0), _offset(0), _content(0), _level(0) { _children.push_back(child); _value.type = ebml_type_t::kEBMLTypeMaster; }
+		explicit ebml_element_t(ebml_id_t id, vec children) :_id(id), _size(0), _offset(0), _content(0), _level(0), _children(children) { _value.type = ebml_type_t::kEBMLTypeMaster; }
+		virtual ~ebml_element_t() noexcept {}
+
+		ebml_size_t content_size() const;
+		ebml_size_t size() const;
+		void WriteVINT(XMP_IO * fileRef, const ebml_vint_t & value, bool adjust);
+		void write(XMP_IO* fileRef);
+		void update_header(XMP_IO* fileRef);
+		void update_content(XMP_IO* fileRef);
+		void wipe(XMP_IO * fileRef);
+		vec getElementsById(ebml_id_t id) const noexcept;
+		ptr getElementById(ebml_id_t id) const;
+
+		std::string _name;
+		ebml_vint_t _id, _size;
+		ebml_offset_t _offset, _content;
+		ebml_level_t _level;
+		ebml_variant_t _value;
+		vec _children;
+	};
+}
+
+#endif /* _EBML_element_h_ */

--- a/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/exceptions.h
+++ b/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/exceptions.h
@@ -1,0 +1,58 @@
+// =================================================================================================
+// ADOBE SYSTEMS INCORPORATED
+// Copyright 2016 Adobe Systems Incorporated
+// All Rights Reserved
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+// =================================================================================================
+
+#ifndef _EBML_exceptions_h_
+#define _EBML_exceptions_h_
+
+namespace ebml
+{
+	class invalid_type : public std::logic_error
+	{
+	public:
+		explicit invalid_type() : std::logic_error("invalid type") {}
+	};
+
+	class invalid_size : public std::logic_error
+	{
+	public:
+		explicit invalid_size() : std::logic_error("invalid size") {}
+	};
+
+	class invalid_level : public std::logic_error
+	{
+	public:
+		explicit invalid_level() : std::logic_error("invalid level") {}
+	};
+
+	class invalid_doctype : public std::logic_error
+	{
+	public:
+		explicit invalid_doctype() : std::logic_error("invalid doctype") {}
+	};
+
+	class read_error : public std::logic_error
+	{
+	public:
+		explicit read_error() : std::logic_error("read error") {}
+	};
+
+	class parsing_aborted : public std::logic_error
+	{
+	public:
+		explicit parsing_aborted() : std::logic_error("parsing aborted") {}
+	};
+
+	class no_elements : public std::logic_error
+	{
+	public:
+		explicit no_elements() : std::logic_error("no elements") {}
+	};
+}
+
+#endif /* _EBML_exceptions_h_ */

--- a/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/ids.h
+++ b/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/ids.h
@@ -1,0 +1,33 @@
+// =================================================================================================
+// ADOBE SYSTEMS INCORPORATED
+// Copyright 2016 Adobe Systems Incorporated
+// All Rights Reserved
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+// =================================================================================================
+
+#ifndef _EBML_ids_h_
+#define _EBML_ids_h_
+
+namespace ebml
+{
+	/* minimal set of common EBML Ids used in Matroska, according to the official specification http://matroska.org/technical/specs/index.html */
+	static constexpr ebml_id_t kEBML = 0x1A45DFA3ULL;
+	static constexpr ebml_id_t kDocType = 0x4282ULL;
+	static constexpr ebml_id_t kEBMLMaxIDLength = 0x42F2;
+	static constexpr ebml_id_t kEBMLMaxSizeLength = 0x42F3;
+	static constexpr ebml_id_t kSegment = 0x18538067;
+	static constexpr ebml_id_t kTags = 0x1254C367;
+	static constexpr ebml_id_t kTag = 0x7373;
+	static constexpr ebml_id_t kTargets = 0x63C0;
+	static constexpr ebml_id_t kTargetType = 0x63CA;
+	static constexpr ebml_id_t kSimpleTag = 0x67C8;
+	static constexpr ebml_id_t kTagName = 0x45A3;
+	static constexpr ebml_id_t kTagString = 0x4487;
+	static constexpr ebml_id_t kTagLanguage = 0x447A;
+	static constexpr ebml_id_t kTagDefault = 0x4484;
+	static constexpr ebml_id_t kVoid = 0xEC;
+}
+
+#endif /* _EBML_ids_h_ */

--- a/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/ids.h
+++ b/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/ids.h
@@ -13,21 +13,21 @@
 namespace ebml
 {
 	/* minimal set of common EBML Ids used in Matroska, according to the official specification http://matroska.org/technical/specs/index.html */
-	static constexpr ebml_id_t kEBML = 0x1A45DFA3ULL;
-	static constexpr ebml_id_t kDocType = 0x4282ULL;
-	static constexpr ebml_id_t kEBMLMaxIDLength = 0x42F2;
-	static constexpr ebml_id_t kEBMLMaxSizeLength = 0x42F3;
-	static constexpr ebml_id_t kSegment = 0x18538067;
-	static constexpr ebml_id_t kTags = 0x1254C367;
-	static constexpr ebml_id_t kTag = 0x7373;
-	static constexpr ebml_id_t kTargets = 0x63C0;
-	static constexpr ebml_id_t kTargetType = 0x63CA;
-	static constexpr ebml_id_t kSimpleTag = 0x67C8;
-	static constexpr ebml_id_t kTagName = 0x45A3;
-	static constexpr ebml_id_t kTagString = 0x4487;
-	static constexpr ebml_id_t kTagLanguage = 0x447A;
-	static constexpr ebml_id_t kTagDefault = 0x4484;
-	static constexpr ebml_id_t kVoid = 0xEC;
+	static const ebml_id_t kEBML = 0x1A45DFA3ULL;
+	static const ebml_id_t kDocType = 0x4282ULL;
+	static const ebml_id_t kEBMLMaxIDLength = 0x42F2;
+	static const ebml_id_t kEBMLMaxSizeLength = 0x42F3;
+	static const ebml_id_t kSegment = 0x18538067;
+	static const ebml_id_t kTags = 0x1254C367;
+	static const ebml_id_t kTag = 0x7373;
+	static const ebml_id_t kTargets = 0x63C0;
+	static const ebml_id_t kTargetType = 0x63CA;
+	static const ebml_id_t kSimpleTag = 0x67C8;
+	static const ebml_id_t kTagName = 0x45A3;
+	static const ebml_id_t kTagString = 0x4487;
+	static const ebml_id_t kTagLanguage = 0x447A;
+	static const ebml_id_t kTagDefault = 0x4484;
+	static const ebml_id_t kVoid = 0xEC;
 }
 
 #endif /* _EBML_ids_h_ */

--- a/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/variant.cpp
+++ b/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/variant.cpp
@@ -1,0 +1,66 @@
+// =================================================================================================
+// ADOBE SYSTEMS INCORPORATED
+// Copyright 2016 Adobe Systems Incorporated
+// All Rights Reserved
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+// =================================================================================================
+
+#include "XMPFiles/source/FormatSupport/EBML_Support.hpp"
+#include "XMPFiles/source/FormatSupport/EBML/exceptions.h"
+#include "XMPFiles/source/FormatSupport/EBML/variant.h"
+
+namespace ebml
+{
+	ebml_size_t ebml_variant_t::size() const
+	{
+		ebml_size_t result(0);
+		switch (type)
+		{
+		case ebml_type_t::kEBMLTypeString:
+		case ebml_type_t::kEBMLTypeUTF8: result = StringValue.size(); break;
+		case ebml_type_t::kEBMLTypeUnsigned:
+		case ebml_type_t::kEBMLTypeSigned:
+		case ebml_type_t::kEBMLTypeFloat:
+		case ebml_type_t::kEBMLTypeDate: result = 8; break; // for integral types always use 8 byte to represent them
+		case ebml_type_t::kEBMLTypeBinary: result = BinaryValue.size(); break;
+		default: throw invalid_type();
+		}
+		return result;
+	}
+
+	const void * ebml_variant_t::data() const
+	{
+		const void * result(nullptr);
+		switch (type)
+		{
+		case ebml_type_t::kEBMLTypeUnsigned: result = &UnsignedValue; break;
+		case ebml_type_t::kEBMLTypeSigned: result = &SignedValue; break;
+		case ebml_type_t::kEBMLTypeString:
+		case ebml_type_t::kEBMLTypeUTF8: result = StringValue.c_str(); break;
+		case ebml_type_t::kEBMLTypeBinary: result = &BinaryValue[0]; break;
+		case ebml_type_t::kEBMLTypeFloat: result = &FloatValue; break;
+		case ebml_type_t::kEBMLTypeDate: result = &DateValue; break;
+		default: throw invalid_type();
+		}
+		return result;
+	}
+
+	std::string ebml_variant_t::to_string() const
+	{
+		std::stringstream stream;
+		switch (type)
+		{
+		case ebml_type_t::kEBMLTypeUnsigned: stream << UnsignedValue; break;
+		case ebml_type_t::kEBMLTypeSigned: stream << SignedValue; break;
+		case ebml_type_t::kEBMLTypeString: stream << StringValue; break;
+		case ebml_type_t::kEBMLTypeUTF8: stream << StringValue; break;
+		case ebml_type_t::kEBMLTypeDate: stream << DateValue; break;
+		case ebml_type_t::kEBMLTypeFloat: stream << FloatValue; break;
+		case ebml_type_t::kEBMLTypeBinary: for (auto i : BinaryValue) stream << std::hex << " " << i; break;
+		default: throw invalid_type();
+		}
+		return stream.str();
+	}
+}

--- a/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/variant.h
+++ b/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/variant.h
@@ -10,6 +10,12 @@
 #ifndef _EBML_variant_h_
 #define _EBML_variant_h_
 
+#if !defined(_MSC_FULL_VER) || _MSC_FULL_VER < 190023026
+  // MSVC before 2015 doesn't support 'noexcept'
+  #define _ALLOW_KEYWORD_MACROS 1
+  #define noexcept throw()
+#endif
+
 namespace ebml
 {
 	class ebml_variant_t

--- a/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/variant.h
+++ b/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML/variant.h
@@ -1,0 +1,41 @@
+// =================================================================================================
+// ADOBE SYSTEMS INCORPORATED
+// Copyright 2016 Adobe Systems Incorporated
+// All Rights Reserved
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+// =================================================================================================
+
+#ifndef _EBML_variant_h_
+#define _EBML_variant_h_
+
+namespace ebml
+{
+	class ebml_variant_t
+	{
+	public:
+		explicit ebml_variant_t() noexcept : type(ebml_type_t::kEBMLTypeUnknown) {}
+		explicit ebml_variant_t(ebml_unsigned_t value) : UnsignedValue(value), type(ebml_type_t::kEBMLTypeUnsigned) {}
+		explicit ebml_variant_t(ebml_signed_t value) : SignedValue(value), type(ebml_type_t::kEBMLTypeSigned) {}
+		explicit ebml_variant_t(const char * value) : StringValue(value ? value : ""), type(ebml_type_t::kEBMLTypeString) {}
+		explicit ebml_variant_t(const ebml_string_t & value) : StringValue(value), type(ebml_type_t::kEBMLTypeString) {}
+		explicit ebml_variant_t(const ebml_binary_t & value) : BinaryValue(value), type(ebml_type_t::kEBMLTypeBinary) {}
+		explicit ebml_variant_t(ebml_float_t value) : FloatValue(value), type(ebml_type_t::kEBMLTypeFloat) {}
+		virtual ~ebml_variant_t() noexcept {}
+
+		ebml_size_t size() const;
+		const void * data() const;
+		std::string to_string() const;
+
+		ebml_unsigned_t UnsignedValue;
+		ebml_signed_t SignedValue;
+		ebml_string_t StringValue;
+		ebml_binary_t BinaryValue;
+		ebml_float_t FloatValue;
+		ebml_date_t DateValue;
+		ebml_type_t type;
+	};
+}
+
+#endif /* _EBML_variant_h_ */

--- a/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML_Support.cpp
+++ b/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML_Support.cpp
@@ -1,0 +1,278 @@
+// =================================================================================================
+// ADOBE SYSTEMS INCORPORATED
+// Copyright 2016 Adobe Systems Incorporated
+// All Rights Reserved
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+// =================================================================================================
+
+#include "XMPFiles/source/FormatSupport/EBML_Support.hpp"
+#include "XMPFiles/source/FormatSupport/EBML/ids.h"
+#include "XMPFiles/source/FormatSupport/EBML/exceptions.h"
+#include "XMPFiles/source/FormatSupport/EBML/variant.h"
+#include "XMPFiles/source/FormatSupport/EBML/element.h"
+
+#ifndef EBML_VERBOSE
+#define EBML_VERBOSE 0 /* use for debugging */
+#endif /* EBML_VERBOSE */
+
+namespace
+{
+	using namespace ebml;
+
+	static ebml_string_t ReadString(XMP_IO * fileRef, ebml_size_t size)
+	{
+		XMP_Assert(fileRef);
+		std::string result;
+		for (size_t i(0); i < size; ++i)
+		{
+			char byte(0);
+			if (1 != fileRef->ReadAll(&byte, 1)) throw read_error();
+			result.push_back(byte);
+		}
+		return result;
+	}
+
+	static ebml_unsigned_t ReadUnsigned(XMP_IO * fileRef, ebml_size_t size)
+	{
+		XMP_Assert(fileRef);
+		ebml_unsigned_t result(0);
+		if (size > 8) throw invalid_size();
+		for (size_t i(0); i < size; ++i)
+		{
+			XMP_Uns8 byte(0);
+			if (1 != fileRef->ReadAll(&byte, 1)) throw read_error();
+			result = (result << 8) | byte;
+		}
+		return result;
+	}
+
+	static ebml_signed_t ReadSigned(XMP_IO * fileRef, ebml_size_t size)
+	{
+		XMP_Assert(fileRef);
+		ebml_signed_t result(0);
+		if (size > 8) throw invalid_size();
+		if (size > 0)
+		{
+			XMP_Uns8 byte(0);
+			if (1 != fileRef->ReadAll(&byte, 1)) throw read_error();
+
+			result = (byte & 0x80) ? -1 : 0;
+			result |= byte & ~0x80;
+
+			for (size_t i(0); i < size - 1; ++i)
+			{
+				if (1 != fileRef->ReadAll(&byte, 1)) throw read_error();
+				result = (result << 8) | byte;
+			}
+		}
+		return result;
+	}
+
+	static ebml_float_t ReadFloat(XMP_IO * fileRef, ebml_size_t size)
+	{
+		XMP_Assert(fileRef);
+		ebml_float_t result(.0);
+		if (size == 4)
+		{
+			float dummy(.0f);
+			if (4 != fileRef->ReadAll(&dummy, 4)) throw read_error();
+			result = dummy;
+		}
+		else if (size == 8)
+		{
+			if (8 != fileRef->ReadAll(&result, 8)) throw read_error();
+		}
+		else throw invalid_size();
+		return result;
+	}
+
+	static ebml_date_t ReadDate(XMP_IO * fileRef, ebml_size_t size)
+	{
+		XMP_Assert(fileRef);
+		ebml_date_t result(0);
+		if (size == 8)
+		{
+			if (8 != fileRef->ReadAll(&result, 8)) throw read_error();
+		}
+		else invalid_size();
+		return result;
+	}
+
+	static ebml_binary_t ReadBinary(XMP_IO * fileRef, ebml_size_t size)
+	{
+		XMP_Assert(fileRef);
+		ebml_binary_t result(size);
+		if (size)
+		{
+			if (size != fileRef->ReadAll(&result[0], size)) throw read_error();
+		}
+		return result;
+	}
+
+	static ebml_variant_t ReadVariant(XMP_IO * fileRef, ebml_size_t size, ebml_type_t type)
+	{
+		XMP_Assert(fileRef);
+		ebml_variant_t result;
+		switch (result.type = type)
+		{
+		case ebml_type_t::kEBMLTypeUnsigned: result.UnsignedValue = ReadUnsigned(fileRef, size); break;
+		case ebml_type_t::kEBMLTypeSigned: result.SignedValue = ReadSigned(fileRef, size); break;
+		case ebml_type_t::kEBMLTypeString:
+		case ebml_type_t::kEBMLTypeUTF8: result.StringValue = ReadString(fileRef, size); break;
+		case ebml_type_t::kEBMLTypeDate: result.DateValue = ReadDate(fileRef, size); break;
+		case ebml_type_t::kEBMLTypeFloat: result.FloatValue = ReadFloat(fileRef, size); break;
+		case ebml_type_t::kEBMLTypeBinary: result.BinaryValue = ReadBinary(fileRef, size); break;
+		default: throw invalid_type();
+		}
+		return result;
+	}
+
+	static ebml_vint_t ReadVINT(XMP_IO* fileRef, bool clear, ebml_unsigned_t max_size)
+	{
+		XMP_Assert(fileRef);
+
+		XMP_Uns8 byte(0);
+		if (1 != fileRef->ReadAll(&byte, 1)) throw read_error();
+
+		XMP_Uns8 count(1);
+		XMP_Uns8 mask(0x80);
+
+		while (mask > 0)
+		{
+			if (mask & byte) break;
+			++count;
+			mask >>= 1;
+		}
+		if (!mask) throw invalid_size();
+
+		ebml_size_t value = clear ? (byte & ~mask) : byte;
+
+		if (max_size != kEbmlInvalid && count > max_size) throw invalid_size();
+
+		for (XMP_Uns8 i(0); i < count - 1; ++i)
+		{
+			if (1 != fileRef->ReadAll(&byte, 1)) throw read_error();
+			value = (value << 8) | byte;
+		}
+		return ebml_vint_t{ count, value };
+	}
+
+	static ebml_size_t ReadEBMLHeader(XMP_IO* fileRef, ebml_restrictions_t & restrictions, ebml_vint_t & id, ebml_vint_t & size)
+	{
+		XMP_Assert(fileRef);
+
+		id = ReadVINT(fileRef, false, restrictions.max_id_length);
+		size = ReadVINT(fileRef, true, restrictions.max_size_length);
+		return id._length + size._length;
+	}
+
+	typedef struct ebml_table_t
+	{
+		ebml_id_t id;
+		ebml_type_t type;
+		ebml_string_t name;
+		ebml_level_t min_level;
+		ebml_level_t max_level;
+	}
+	ebml_table;
+
+	static const ebml_table_t elements[] =
+	{
+		{ kEBML, ebml_type_t::kEBMLTypeMaster, "EBML", 0, 0 },
+		{ kDocType, ebml_type_t::kEBMLTypeString, "DocType", 1, 1 },
+		{ kEBMLMaxIDLength, ebml_type_t::kEBMLTypeUnsigned, "EBMLMaxIDLength", 1, 1 },
+		{ kEBMLMaxSizeLength, ebml_type_t::kEBMLTypeUnsigned, "EBMLMaxSizeLength", 1, 1 },
+		{ kSegment, ebml_type_t::kEBMLTypeMaster, "Segment", 0, 0 },
+		{ kTags, ebml_type_t::kEBMLTypeMaster, "Tags", 1, 1 },
+		{ kTag, ebml_type_t::kEBMLTypeMaster, "Tag", 2, 2 },
+		{ kTargets, ebml_type_t::kEBMLTypeMaster, "Targets", 3, 3 },
+		{ kTargetType, ebml_type_t::kEBMLTypeString, "TargetType", 4, 4 },
+		{ kSimpleTag, ebml_type_t::kEBMLTypeMaster, "SimpleTag", 3, kEbmlInvalid },
+		{ kTagName, ebml_type_t::kEBMLTypeUTF8, "TagName", 4, kEbmlInvalid },
+		{ kTagString, ebml_type_t::kEBMLTypeUTF8, "TagString", 4, kEbmlInvalid },
+		{ kTagLanguage, ebml_type_t::kEBMLTypeString, "TagLanguage", 4, kEbmlInvalid },
+		{ kTagDefault, ebml_type_t::kEBMLTypeUnsigned, "TagDefault", 4, kEbmlInvalid },
+		{ kVoid, ebml_type_t::kEBMLTypeBinary, "Void", 0, kEbmlInvalid }
+	};
+
+	static ebml_type_t element_type(ebml_id_t id) noexcept
+	{
+		for (auto i : elements) if (i.id == id) return i.type;
+		return ebml_type_t::kEBMLTypeUnknown;
+	}
+
+	static std::string element_name(ebml_id_t id) noexcept
+	{
+		for (auto i : elements) if (i.id == id) return i.name;
+		return std::string();
+	}
+
+	static void check_level(ebml_id_t id, ebml_level_t level)
+	{
+		for (auto i : elements)
+		{
+			if (i.id == id)
+			{
+				if (level < i.min_level || level > i.max_level) throw invalid_level();
+				break;
+			}
+		}
+	}
+}
+
+namespace ebml
+{
+	void ReadEBMLMaster(XMP_IO * fileRef, ebml_element_t::ptr parent, ebml_restrictions_t & restrictions, ebml_level_t level, on_element_t callback)
+	{
+		XMP_Assert(fileRef);
+
+		XMP_Int64 offset = fileRef->Offset() + parent->_size._value;
+
+		for (ebml_size_t count(0); count < parent->_size._value;)
+		{
+			auto element = std::make_shared<ebml_element_t>();
+
+			element->_offset = fileRef->Offset();
+			
+			count += ReadEBMLHeader(fileRef, restrictions, element->_id, element->_size);
+
+			element->_content = fileRef->Offset();
+			
+			element->_level = level;
+			element->_value.type = element_type(element->_id._value);
+			element->_name = element_name(element->_id._value);
+#if EBML_VERBOSE
+			for (ebml_level_t i(0); i < level; ++i) std::cout << "\t";
+			std::cout << char(element->_value.type) << " " << std::hex << element->_id._value << " " << element->_name << " " << std::dec << element->_size._value << std::endl;
+#endif /* EBML_VERBOSE */
+			check_level(element->_id._value, level);
+
+			if (element->_value.type == ebml_type_t::kEBMLTypeMaster) ReadEBMLMaster(fileRef, element, restrictions, level + 1, callback);
+			else if (element->_value.type == ebml_type_t::kEBMLTypeUnknown) fileRef->Seek(element->_size._value, kXMP_SeekFromCurrent);
+			else
+			{
+				element->_value = ReadVariant(fileRef, element->_size._value, element->_value.type);
+#if EBML_VERBOSE
+				for (ebml_level_t i(0); i < level; ++i) std::cout << "\t";
+				std::cout << element->_value.to_string() << std::endl;
+#endif /* EBML_VERBOSE */
+				if (element->_id._value == kEBMLMaxIDLength) restrictions.max_id_length = element->_value.UnsignedValue;
+				else if (element->_id._value == kEBMLMaxSizeLength) restrictions.max_size_length = element->_value.UnsignedValue;
+				else if (element->_id._value == kDocType)
+				{
+					if (element->_value.StringValue != kDocTypeMatroska && element->_value.StringValue != kDocTypeWebM) throw invalid_doctype();
+				}
+			}
+			if (callback)
+			{
+				if (!callback(element)) throw parsing_aborted();
+			}
+			parent->_children.push_back(element);
+
+			count += element->_size._value;
+		}
+		fileRef->Seek(offset, kXMP_SeekFromStart);
+	}
+}

--- a/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML_Support.hpp
+++ b/3rdparty/xmp/XMPFiles/source/FormatSupport/EBML_Support.hpp
@@ -1,0 +1,100 @@
+#ifndef __EBML_Support_hpp__
+#define __EBML_Support_hpp__ 1
+
+// =================================================================================================
+// ADOBE SYSTEMS INCORPORATED
+// Copyright 2016 Adobe Systems Incorporated
+// All Rights Reserved
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in accordance with the terms
+// of the Adobe license agreement accompanying it.
+// =================================================================================================
+
+#include "public/include/XMP_Environment.h"	// ! XMP_Environment.h must be the first included header.
+
+#include "public/include/XMP_Const.h"
+#include "public/include/XMP_IO.hpp"
+
+#include "XMPFiles/source/XMPFiles_Impl.hpp"
+#include "source/XMPFiles_IO.hpp"
+
+#include <string>
+#include <vector>
+#include <numeric>
+#include <iostream>
+#include <sstream>
+#include <memory>
+#include <stdexcept>
+#include <functional>
+#include <limits>
+
+namespace ebml
+{
+	typedef XMP_Int64 ebml_offset_t;
+	typedef XMP_Uns64 ebml_size_t;
+	typedef XMP_Uns64 ebml_id_t;
+	typedef XMP_Uns64 ebml_date_t;
+	typedef XMP_Uns64 ebml_unsigned_t;
+	typedef XMP_Int64 ebml_signed_t;
+	typedef std::string ebml_string_t;
+	typedef std::string ebml_utf8_t;
+	typedef double ebml_float_t;
+	typedef XMP_Uns64 ebml_level_t;
+
+	template<typename T>
+	ebml_size_t size_for_int(T value)
+	{
+		ebml_size_t result(1); // always use at least one byte to represent integer value
+		value >>= 8;
+		while (value)
+		{
+			++result;
+			value >>= 8;
+		}
+		return result;
+	}
+
+	typedef struct ebml_vint_t
+	{
+		explicit ebml_vint_t(ebml_size_t length, ebml_size_t value) : _length(length), _value(value) {}
+		explicit ebml_vint_t(ebml_size_t value) : _length(size_for_int(value)), _value(value) {}
+		ebml_size_t _length;
+		ebml_size_t _value;
+	}
+	ebml_vint;
+
+	typedef std::vector<XMP_Uns8> ebml_binary_t;
+
+	enum class ebml_type_t : char
+	{
+		kEBMLTypeMaster = 'm',
+		kEBMLTypeUnsigned = 'u',
+		kEBMLTypeSigned = 'i',
+		kEBMLTypeString = 's',
+		kEBMLTypeUTF8 = '8',
+		kEBMLTypeBinary = 'b',
+		kEBMLTypeFloat = 'f',
+		kEBMLTypeDate = 'd',
+		kEBMLTypeUnknown = '?'
+	};
+
+	static const ebml_string_t kDocTypeMatroska = "matroska";
+	static const ebml_string_t kDocTypeWebM = "webm";	
+
+	static const ebml_unsigned_t kEbmlInvalid = (std::numeric_limits<ebml_unsigned_t>::max)();
+
+	typedef struct ebml_restrictions_t
+	{
+		ebml_unsigned_t max_id_length;
+		ebml_unsigned_t max_size_length;
+	}
+	ebml_restrictions;
+
+	class ebml_element_t;
+
+	typedef std::function<bool(std::shared_ptr<ebml_element_t>)> on_element_t;
+
+	void ReadEBMLMaster(XMP_IO * fileRef, std::shared_ptr<ebml_element_t> parent, ebml_restrictions_t & restrictions, ebml_level_t level, on_element_t callback);
+}
+
+#endif	// __EBML_Support_hpp__

--- a/3rdparty/xmp/XMPFiles/source/HandlerRegistry.cpp
+++ b/3rdparty/xmp/XMPFiles/source/HandlerRegistry.cpp
@@ -38,6 +38,7 @@
 	#include "XMPFiles/source/FileHandlers/SWF_Handler.hpp"
 	#include "XMPFiles/source/FileHandlers/XDCAM_Handler.hpp"
 	#include "XMPFiles/source/FileHandlers/XDCAMEX_Handler.hpp"
+	#include "XMPFiles/source/FileHandlers/Matroska_Handler.hpp"
 #endif
 
 #if EnableMiscHandlers
@@ -145,6 +146,7 @@ void HandlerRegistry::initialize()
 	allOK &= this->registerNormalHandler ( kXMP_MOVFile, kMPEG4_HandlerFlags, MPEG4_CheckFormat, MPEG4_MetaHandlerCTor );	// ! Yes, MPEG-4 includes MOV.
 	allOK &= this->registerNormalHandler ( kXMP_FLVFile, kFLV_HandlerFlags, FLV_CheckFormat, FLV_MetaHandlerCTor );
 	allOK &= this->registerNormalHandler ( kXMP_AIFFFile, kAIFF_HandlerFlags, AIFF_CheckFormat, AIFF_MetaHandlerCTor );
+	allOK &= this->registerNormalHandler ( kXMP_MatroskaFile, kMatroska_HandlerFlags, Matroska_CheckFormat, Matroska_MetaHandlerCTor);
 #endif
 
 #if EnableMiscHandlers

--- a/3rdparty/xmp/XMPFiles/source/XMPFiles_Impl.cpp
+++ b/3rdparty/xmp/XMPFiles/source/XMPFiles_Impl.cpp
@@ -142,6 +142,10 @@ const FileExtMapping kFileExtMap[] =
 	  { "idml", kXMP_UCFFile },
 	  { "idap", kXMP_UCFFile },
 	  { "icap", kXMP_UCFFile },
+	  { "mkv", kXMP_MatroskaFile },
+	  { "mka", kXMP_MatroskaFile },
+	  { "mks", kXMP_MatroskaFile },
+	  { "mk3d", kXMP_MatroskaFile },
 	  { "", 0 } };	// ! Must be last as a sentinel.
 
 // Files known to contain XMP but have no smart handling, here or elsewhere.

--- a/3rdparty/xmp/public/include/XMP_Const.h
+++ b/3rdparty/xmp/public/include/XMP_Const.h
@@ -931,7 +931,8 @@ enum {
     kXMP_XMLFile             = 0x584D4C20UL,
 	/// Public file format constant:  'text'
     kXMP_TextFile            = 0x74657874UL,
-
+    /// Public file format constant:  'MKV ', http://matroska.org/technical/specs/index.html
+    kXMP_MatroskaFile        = 0x4D4B5620UL,
 	// -------------------------------
     // Adobe application file formats.
 


### PR DESCRIPTION
this pull request add Matroska (MKV) format support into the VMF library http://matroska.org/technical/specs/index.html. reading VMF from file, adding VMF to the existing file and updating VMF in existing file - are supported. basically, code is adding new Tag element which contains XMP metadata as payload.
